### PR TITLE
Microwave Source Driver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,5 @@ target/
 tmp/
 
 docs/examples/data/*
+
+.idea/

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.6.0 (C:\ProgramData\Anaconda3\python.exe)" project-jdk-type="Python SDK" />
-</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
  - defaults
  - conda-forge
 dependencies:
- - h5py=2.6.0
+ - h5py
  - matplotlib=2.0.2
  - pyqtgraph 
  - python=3.6

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -514,8 +514,11 @@ class _BaseParameter(Metadatable, DeferredOperations):
     # Deprecated
     @property
     def full_name(self):
-        warnings.warn('Attribute `full_name` is deprecated, please use '
-                      'str(parameter)')
+#        This can fully be replaced by str(parameter) in the future we
+#        may want to deprecate this but the current dataset makes heavy use
+#        of it in more complicated ways so keep it for now.
+#        warnings.warn('Attribute `full_name` is deprecated, please use '
+#                      'str(parameter)')
         return str(self)
 
     def set_validator(self, vals):

--- a/qcodes/instrument_drivers/Harvard/Decadac.py
+++ b/qcodes/instrument_drivers/Harvard/Decadac.py
@@ -1,6 +1,6 @@
 from time import time
 from functools import partial
-from qcodes import VisaInstrument, InstrumentChannel, ChannelList, ManualParameter
+from qcodes import VisaInstrument, InstrumentChannel, ChannelList
 from qcodes.utils import validators as vals
 
 
@@ -199,9 +199,9 @@ class DacChannel(InstrumentChannel, DacReader):
 
         # Manual parameters to control whether DAC channels should ramp to voltages or jump
         self._ramp_val = vals.Numbers(0, 10)
-        self.add_parameter("enable_ramp", parameter_class=ManualParameter, initial_value=False,
+        self.add_parameter("enable_ramp", get_cmd=None, set_cmd=None, initial_value=False,
                            vals=vals.Bool())
-        self.add_parameter("ramp_rate", parameter_class=ManualParameter, initial_value=0.1,
+        self.add_parameter("ramp_rate", get_cmd=None, set_cmd=None, initial_value=0.1,
                            vals=self._ramp_val, unit="V/s")
 
         # Add ramp function to the list of functions

--- a/qcodes/instrument_drivers/Keysight/KeysightAgilent_33XXX.py
+++ b/qcodes/instrument_drivers/Keysight/KeysightAgilent_33XXX.py
@@ -1,38 +1,42 @@
-import warnings
+from functools import partial
+import logging
 
 from qcodes import VisaInstrument, validators as vals
-from functools import partial
-from qcodes.instrument.channel import InstrumentChannel, ChannelList
-import logging
+from qcodes.instrument.channel import InstrumentChannel
+from qcodes.instrument.base import Instrument
 
 log = logging.getLogger(__name__)
 
 
-class KeysightChannel(InstrumentChannel):
-    """
+# This is to be the grand unified driver superclass for
+# The Keysight/Agilent/HP Waveform generators of series
+# 33200, 33500, and 33600
 
 
+class OutputChannel(InstrumentChannel):
     """
-    def __init__(self, parent, name, channum):
+    Class to hold the output channel of a waveform generator
+    """
+    def __init__(self, parent: Instrument, name: str, channum: int) -> None:
         """
         Args:
-            parent (Instrument): The instrument to which the channel is
+            parent: The instrument to which the channel is
                 attached.
-            name (str): The name of the channel
-            channum (int): The number of the channel in question (1-2)
+            name: The name of the channel
+            channum: The number of the channel in question (1-2)
         """
         super().__init__(parent, name)
 
-        def val_parser(parser, inputstring):
+        def val_parser(parser: type, inputstring: str) -> str:
             """
             Parses return values from instrument. Meant to be used when a query
             can return a meaningful finite number or a numeric representation
             of infinity
 
             Args:
-                inputstring (str): The raw return value
-                parser (type): Either int or float, what to return in finite
+                parser: Either int or float, what to return in finite
                     cases
+                inputstring: The raw return value
             """
 
             inputstring = inputstring.strip()
@@ -45,6 +49,8 @@ class KeysightChannel(InstrumentChannel):
                     output = parser(output)
 
             return output
+
+        self.model = self._parent.model
 
         self.add_parameter('function_type',
                            label='Channel {} function type'.format(channum),
@@ -64,6 +70,7 @@ class KeysightChannel(InstrumentChannel):
                            vals=vals.Enum('CW', 'LIST', 'SWEEP', 'FIXED')
                            )
 
+        max_freq = self._parent._max_freqs[self.model]
         self.add_parameter('frequency',
                            label='Channel {} frequency'.format(channum),
                            set_cmd='SOURce{}:FREQuency {{}}'.format(channum),
@@ -71,7 +78,7 @@ class KeysightChannel(InstrumentChannel):
                            get_parser=float,
                            unit='Hz',
                            # TODO: max. freq. actually really tricky
-                           vals=vals.Numbers(1e-6, 30e6)
+                           vals=vals.Numbers(1e-6, max_freq)
                            )
 
         self.add_parameter('phase',
@@ -129,25 +136,6 @@ class KeysightChannel(InstrumentChannel):
                            get_parser=str.rstrip,
                            )
 
-        self.add_parameter('trigger_count',
-                           label='Channel {} trigger count'.format(channum),
-                           set_cmd='TRIGger{}:COUNt {{}}'.format(channum),
-                           get_cmd='TRIGger{}:COUNt?'.format(channum),
-                           vals=vals.Ints(1, 1000000),
-                           get_parser=partial(val_parser, int)
-                           )
-
-        self.add_parameter('trigger_delay',
-                           label='Channel {} trigger delay'.format(channum),
-                           set_cmd='TRIGger{}:DELay {{}}'.format(channum),
-                           get_cmd='TRIGger{}:DELay?'.format(channum),
-                           vals=vals.Numbers(0, 1000),
-                           get_parser=float,
-                           unit='s'
-                           )
-
-        # TODO: trigger level doesn't work remotely. Why?
-
         self.add_parameter('trigger_slope',
                            label='Channel {} trigger slope'.format(channum),
                            set_cmd='TRIGger{}:SLOPe {{}}'.format(channum),
@@ -156,13 +144,32 @@ class KeysightChannel(InstrumentChannel):
                            get_parser=str.rstrip
                            )
 
-        self.add_parameter('trigger_timer',
-                           label='Channel {} trigger timer'.format(channum),
-                           set_cmd='TRIGger{}:TIMer {{}}'.format(channum),
-                           get_cmd='TRIGger{}:TIMer?'.format(channum),
-                           vals=vals.Numbers(1e-6, 8000),
-                           get_parser=float
-                           )
+        # Older models do not have all the fancy trigger options
+        if self._parent.model[2] in ['5', '6']:
+            self.add_parameter('trigger_count',
+                               label='Channel {} trigger count'.format(channum),
+                               set_cmd='TRIGger{}:COUNt {{}}'.format(channum),
+                               get_cmd='TRIGger{}:COUNt?'.format(channum),
+                               vals=vals.Ints(1, 1000000),
+                               get_parser=partial(val_parser, int)
+                               )
+
+            self.add_parameter('trigger_delay',
+                               label='Channel {} trigger delay'.format(channum),
+                               set_cmd='TRIGger{}:DELay {{}}'.format(channum),
+                               get_cmd='TRIGger{}:DELay?'.format(channum),
+                               vals=vals.Numbers(0, 1000),
+                               get_parser=float,
+                               unit='s')
+
+            self.add_parameter('trigger_timer',
+                               label='Channel {} trigger timer'.format(channum),
+                               set_cmd='TRIGger{}:TIMer {{}}'.format(channum),
+                               get_cmd='TRIGger{}:TIMer?'.format(channum),
+                               vals=vals.Numbers(1e-6, 8000),
+                               get_parser=float)
+
+        # TODO: trigger level doesn't work remotely. Why?
 
         # output menu
         self.add_parameter('output_polarity',
@@ -220,7 +227,7 @@ class KeysightChannel(InstrumentChannel):
                            label=('Channel {}'.format(channum) +
                                   ' burst internal period'),
                            set_cmd='SOURce{}:BURSt:INTernal:PERiod {{}}'.format(channum),
-                           get_cmd='SOURce{}:BURSt:INTernal:PERiod'.format(channum),
+                           get_cmd='SOURce{}:BURSt:INTernal:PERiod?'.format(channum),
                            unit='s',
                            vals=vals.Numbers(1e-6, 8e3),
                            get_parser=float,
@@ -230,10 +237,38 @@ class KeysightChannel(InstrumentChannel):
                            )
 
 
-class Keysight_33500B_Channels(VisaInstrument):
+class SyncChannel(InstrumentChannel):
     """
-    QCoDeS driver for the Keysight 33500B Waveform Generator using QCoDeS
-    channels
+    Class to hold the sync output. Has very few parameters for
+    single channel instruments
+    """
+
+    def __init__(self, parent, name):
+
+        super().__init__(parent, name)
+
+        self.add_parameter('output',
+                           label='Sync output state',
+                           set_cmd='OUTPut:SYNC {}',
+                           get_cmd='OUTPut:SYNC?',
+                           val_mapping={'ON': 1, 'OFF': 0},
+                           vals=vals.Enum('ON', 'OFF')
+                           )
+
+        if parent.num_channels == 2:
+
+            self.add_parameter('source',
+                               label='Source of sync function',
+                               set_cmd='OUTPut:SYNC:SOURce {}',
+                               get_cmd='OUTPut:SYNC:SOURce?',
+                               val_mapping={1: 'CH1', 2: 'CH2'},
+                               vals=vals.Enum(1, 2))
+
+
+class WaveformGenerator_33XXX(VisaInstrument):
+    """
+    QCoDeS driver for the Keysight/Agilent 33XXX series of
+    waveform generators
     """
 
     def __init__(self, name, address, silent=False, **kwargs):
@@ -245,13 +280,25 @@ class Keysight_33500B_Channels(VisaInstrument):
             silent (Optional[bool]): If True, no connect message is printed.
         """
 
-        warnings.warn("This driver is old and will be removed "
-                      "from QCoDeS soon. Please use the "
-                      "WaveformGenerator_33XXX from the file "
-                      "instrument_drivers/Keysight/KeysightAgilent_33XXX"
-                      " instead.", UserWarning)
+        super().__init__(name, address, terminator='\n', **kwargs)
+        self.model = self.IDN()['model']
 
-        super().__init__(name, address, **kwargs)
+        #######################################################################
+        # Here go all model specific traits
+
+        # TODO: Fill out this dict with all models
+        no_of_channels = {'33210A': 1,
+                          '33250A': 1,
+                          '33522B': 2,
+                          '33622A': 2
+                          }
+
+        self._max_freqs = {'33210A': 10e6,
+                           '33250A': 80e6,
+                           '33522B': 30e6,
+                           '33622A': 120e6}
+
+        self.num_channels = no_of_channels[self.model]
 
         def errorparser(rawmssg):
             """
@@ -268,29 +315,12 @@ class Keysight_33500B_Channels(VisaInstrument):
 
             return code, mssg
 
-        channels = ChannelList(self, "Channels", KeysightChannel,
-                               snapshotable=False)
-        for i in range(1, 3):
-            channel = KeysightChannel(self, 'ch{}'.format(i), i)
-            channels.append(channel)
-        channels.lock()
-        self.add_submodule('channels', channels)
+        for i in range(1, self.num_channels+1):
+            channel = OutputChannel(self, 'ch{}'.format(i), i)
+            self.add_submodule('ch{}'.format(i), channel)
 
-        self.add_parameter('sync_source',
-                           label='Source of sync function',
-                           set_cmd='OUTPut:SYNC:SOURce {}',
-                           get_cmd='OUTPut:SYNC:SOURce?',
-                           val_mapping={1: 'CH1', 2: 'CH2'},
-                           vals=vals.Enum(1, 2)
-                           )
-
-        self.add_parameter('sync_output',
-                           label='Sync output state',
-                           set_cmd='OUTPut:SYNC {}',
-                           get_cmd='OUTPut:SYNC?',
-                           val_mapping={'ON': 1, 'OFF': 0},
-                           vals=vals.Enum('ON', 'OFF')
-                           )
+        sync = SyncChannel(self, 'sync')
+        self.add_submodule('sync', sync)
 
         self.add_parameter('error',
                            label='Error message',

--- a/qcodes/instrument_drivers/Keysight/Keysight_33500B.py
+++ b/qcodes/instrument_drivers/Keysight/Keysight_33500B.py
@@ -1,6 +1,7 @@
+import warnings
+
 from qcodes import VisaInstrument, validators as vals
 from functools import partial
-from pyvisa.errors import VisaIOError
 import logging
 
 log = logging.getLogger(__name__)
@@ -19,6 +20,12 @@ class Keysight_33500B(VisaInstrument):
             address (string): The VISA resource name.
             silent (Optional[bool]): If True, no connect message is printed.
         """
+
+        warnings.warn("This driver is old and will be removed "
+                      "from QCoDeS soon. Please use the "
+                      "WaveformGenerator_33XXX from the file "
+                      "instrument_drivers/Keysight/KeysightAgilent_33XXX"
+                      " instead.", UserWarning)
 
         super().__init__(name, address, **kwargs)
 

--- a/qcodes/instrument_drivers/QDev/QDac.py
+++ b/qcodes/instrument_drivers/QDev/QDac.py
@@ -10,7 +10,6 @@ from functools import partial
 from operator import xor
 from collections import OrderedDict
 
-from qcodes.instrument.parameter import ManualParameter
 from qcodes.instrument.visa import VisaInstrument
 from qcodes.utils import validators as vals
 
@@ -129,13 +128,13 @@ class QDac(VisaInstrument):
             self.add_parameter(name='ch{:02}_sync_delay'.format(i),
                                label='Channel {} sync pulse delay'.format(i),
                                unit='s',
-                               parameter_class=ManualParameter,
+                               get_cmd=None, set_cmd=None,
                                initial_value=0)
 
             self.add_parameter(name='ch{:02}_sync_duration'.format(i),
                                label='Channel {} sync pulse duration'.format(i),
                                unit='s',
-                               parameter_class=ManualParameter,
+                               get_cmd=None, set_cmd=None,
                                initial_value=0.01)
 
         for board in range(6):
@@ -158,7 +157,7 @@ class QDac(VisaInstrument):
 
         self.add_parameter(name='fast_voltage_set',
                            label='fast voltage set',
-                           parameter_class=ManualParameter,
+                           get_cmd=None, set_cmd=None,
                            vals=vals.Bool(),
                            initial_value=False,
                            docstring=""""Toggles if DC voltage set should unset any ramp attached to this channel.

--- a/qcodes/instrument_drivers/QDev/QDac_channels.py
+++ b/qcodes/instrument_drivers/QDev/QDac_channels.py
@@ -12,7 +12,6 @@ from collections import OrderedDict
 
 from qcodes.instrument.channel import InstrumentChannel, ChannelList
 from qcodes.instrument.channel import MultiChannelInstrumentParameter
-from qcodes.instrument.parameter import ManualParameter
 from qcodes.instrument.visa import VisaInstrument
 from qcodes.utils import validators as vals
 
@@ -93,14 +92,14 @@ class QDacChannel(InstrumentChannel):
         self.add_parameter(name='sync_delay',
                            label='Channel {} sync pulse delay'.format(channum),
                            unit='s',
-                           parameter_class=ManualParameter,
+                           get_cmd=None, set_cmd=None,
                            initial_value=0
                            )
 
         self.add_parameter(name='sync_duration',
                            label='Channel {} sync pulse duration'.format(channum),
                            unit='s',
-                           parameter_class=ManualParameter,
+                           get_cmd=None, set_cmd=None,
                            initial_value=0.01
                            )
 
@@ -246,7 +245,7 @@ class QDac(VisaInstrument):
 
         self.add_parameter(name='fast_voltage_set',
                            label='fast voltage set',
-                           parameter_class=ManualParameter,
+                           get_cmd=None, set_cmd=None,
                            vals=vals.Bool(),
                            initial_value=False,
                            docstring=""""Deprecated with no functionality""")

--- a/qcodes/instrument_drivers/QDev/QDac_channels.py
+++ b/qcodes/instrument_drivers/QDev/QDac_channels.py
@@ -218,7 +218,7 @@ class QDac(VisaInstrument):
                                multichan_paramclass=QDacMultiChannelParameter)
 
         for i in self.chan_range:
-            channel = QDacChannel(self, 'chan{}'.format(i), i)
+            channel = QDacChannel(self, 'chan{:02}'.format(i), i)
             channels.append(channel)
             # Should raise valueerror if name is invalid (silently fails now)
             self.add_submodule('ch{:02}'.format(i), channel)

--- a/qcodes/instrument_drivers/QuTech/IVVI.py
+++ b/qcodes/instrument_drivers/QuTech/IVVI.py
@@ -6,7 +6,6 @@ import traceback
 import threading
 
 from qcodes import VisaInstrument, validators as vals
-from qcodes.instrument.parameter import ManualParameter
 from qcodes.utils.validators import Bool, Numbers
 
 
@@ -80,7 +79,7 @@ class IVVI(VisaInstrument):
                            get_cmd=self._get_version)
 
         self.add_parameter('check_setpoints',
-                           parameter_class=ManualParameter,
+                           get_cmd=None, set_cmd=None,
                            initial_value=False,
                            label='Check setpoints',
                            vals=Bool(),
@@ -90,7 +89,7 @@ class IVVI(VisaInstrument):
 
         # Time to wait before sending a set DAC command to the IVVI
         self.add_parameter('dac_set_sleep',
-                           parameter_class=ManualParameter,
+                           get_cmd=None, set_cmd=None,
                            initial_value=0.05,
                            label='DAC set sleep',
                            unit='s',
@@ -102,7 +101,7 @@ class IVVI(VisaInstrument):
 
         # Minimum time to wait before the read buffer contains data
         self.add_parameter('dac_read_buffer_sleep',
-                           parameter_class=ManualParameter,
+                           get_cmd=None, set_cmd=None,
                            initial_value=0.025,
                            label='DAC read buffer sleep',
                            unit='s',
@@ -511,7 +510,7 @@ class IVVI(VisaInstrument):
         function prevents that.
 
         Args:
-            param (StandardParameter): a dac of the IVVI instrument
+            param (Parameter): a dac of the IVVI instrument
         """
         if not isinstance(param._vals, Numbers):
             raise Exception('Only the Numbers validator is supported.')

--- a/qcodes/instrument_drivers/Spectrum/M4i.py
+++ b/qcodes/instrument_drivers/Spectrum/M4i.py
@@ -17,7 +17,6 @@ import ctypes as ct
 from functools import partial
 from qcodes.utils.validators import Enum, Numbers, Anything
 from qcodes.instrument.base import Instrument
-from qcodes.instrument.parameter import ManualParameter
 try:
     import pyspcm
 except ImportError:
@@ -83,7 +82,7 @@ class M4i(Instrument):
         # add parameters for getting
         self.add_parameter('card_id',
                            label='card id',
-                           parameter_class=ManualParameter,
+                           get_cmd=None, set_cmd=None,
                            initial_value=cardid,
                            vals=Anything(),
                            docstring='The card ID')

--- a/qcodes/instrument_drivers/ZI/ZIUHFLI.py
+++ b/qcodes/instrument_drivers/ZI/ZIUHFLI.py
@@ -10,7 +10,6 @@ except ImportError:
                          download and installation instructions.
                       ''')
 
-from qcodes.instrument.parameter import ManualParameter
 from qcodes.instrument.parameter import MultiParameter
 from qcodes.instrument.base import Instrument
 from qcodes.utils import validators as vals
@@ -796,7 +795,7 @@ class ZIUHFLI(Instrument):
                                 unit='V')
 
             self.add_parameter('signal_output{}_ampdef'.format(sigout),
-                                parameter_class=ManualParameter,
+                                get_cmd=None, set_cmd=None,
                                 initial_value='Vpk',
                                 label="Signal output amplitude's definition",
                                 unit='V',
@@ -1084,7 +1083,7 @@ class ZIUHFLI(Instrument):
                            label='Sweep timeout',
                            unit='s',
                            initial_value=600,
-                           parameter_class=ManualParameter)
+                           get_cmd=None, set_cmd=None)
 
         ########################################
         # THE SWEEP ITSELF

--- a/qcodes/instrument_drivers/agilent/HP33210A.py
+++ b/qcodes/instrument_drivers/agilent/HP33210A.py
@@ -1,3 +1,5 @@
+import warnings
+
 from qcodes import VisaInstrument, validators as vals
 
 
@@ -8,6 +10,13 @@ class Agilent_HP33210A(VisaInstrument):
     Includes the essential commands from the manual
     """
     def __init__(self, name, address, reset=False, **kwargs):
+
+        warnings.warn("This driver is old and will be removed "
+                      "from QCoDeS soon. Please use the "
+                      "WaveformGenerator_33XXX from the file "
+                      "instrument_drivers/Keysight/KeysightAgilent_33XXX"
+                      " instead.", UserWarning)
+
         super().__init__(name, address, terminator='\n', **kwargs)
 
         self.add_parameter(name='frequency',

--- a/qcodes/instrument_drivers/devices.py
+++ b/qcodes/instrument_drivers/devices.py
@@ -1,6 +1,6 @@
 from typing import Union
 
-from qcodes import Parameter, StandardParameter, Instrument
+from qcodes import Parameter, Instrument
 
 
 class VoltageDivider(Parameter):
@@ -44,7 +44,7 @@ class VoltageDivider(Parameter):
     """
 
     def __init__(self,
-                 v1: StandardParameter,
+                 v1: Parameter,
                  division_value: Union[int, float],
                  name: str=None,
                  label: str=None,

--- a/qcodes/instrument_drivers/ithaco/Ithaco_1211.py
+++ b/qcodes/instrument_drivers/ithaco/Ithaco_1211.py
@@ -1,6 +1,5 @@
 from qcodes import Instrument
 from qcodes.instrument.parameter import MultiParameter
-from qcodes.instrument.parameter import ManualParameter
 from qcodes.utils.validators import Enum, Bool
 
 
@@ -65,39 +64,39 @@ class Ithaco_1211(Instrument):
         super().__init__(name, **kwargs)
 
         self.add_parameter('sens',
-                           parameter_class=ManualParameter,
                            initial_value=1e-8,
                            label='Sensitivity',
                            unit='A/V',
+                           get_cmd=None, set_cmd=None,
                            vals=Enum(1e-11, 1e-10, 1e-09, 1e-08, 1e-07,
                                      1e-06, 1e-05, 1e-4, 1e-3))
 
         self.add_parameter('invert',
-                           parameter_class=ManualParameter,
                            initial_value=True,
                            label='Inverted output',
+                           get_cmd=None, set_cmd=None,
                            vals=Bool())
 
         self.add_parameter('sens_factor',
-                           parameter_class=ManualParameter,
                            initial_value=1,
                            label='Sensitivity factor',
                            unit=None,
+                           get_cmd=None, set_cmd=None,
                            vals=Enum(0.1, 1, 10))
 
         self.add_parameter('suppression',
-                           parameter_class=ManualParameter,
                            initial_value=1e-7,
                            label='Suppression',
                            unit='A',
+                           get_cmd=None, set_cmd=None,
                            vals=Enum(1e-10, 1e-09, 1e-08, 1e-07, 1e-06,
                                      1e-05, 1e-4, 1e-3))
 
         self.add_parameter('risetime',
-                           parameter_class=ManualParameter,
                            initial_value=0.3,
                            label='Rise Time',
                            unit='msec',
+                           get_cmd=None, set_cmd=None,
                            vals=Enum(0.01, 0.03, 0.1, 0.3, 1, 3, 10, 30,
                                      100, 300, 1000))
 

--- a/qcodes/instrument_drivers/oxford/mercuryiPS.py
+++ b/qcodes/instrument_drivers/oxford/mercuryiPS.py
@@ -3,7 +3,7 @@ import re
 import time
 import numpy as np
 
-from qcodes import IPInstrument, MultiParameter, ManualParameter
+from qcodes import IPInstrument, MultiParameter
 from qcodes.utils.validators import Enum, Bool
 
 class MercuryiPSArray(MultiParameter):
@@ -80,7 +80,7 @@ class MercuryiPS(IPInstrument):
 
 
         self.add_parameter('hold_after_set',
-                           parameter_class=ManualParameter,
+                           get_cmd=None, set_cmd=None,
                            vals=Bool(),
                            initial_value=False,
                            docstring='Should the driver block while waiting for the Magnet power supply '

--- a/qcodes/instrument_drivers/oxford/mercuryiPS.py
+++ b/qcodes/instrument_drivers/oxford/mercuryiPS.py
@@ -207,8 +207,12 @@ class MercuryiPS(IPInstrument):
         self._set_fld(ax, cmd, setpoint)
         self.rtos()
         if self.hold_after_set():
-            while not all(['HOLD' == getattr(self, a.lower() + '_ACTN')() for a in ax]):
-                time.sleep(0.1)
+            try:
+                while not all(['HOLD' == getattr(self, a.lower() + '_ACTN')() for a in ax]):
+                    time.sleep(0.1)
+            except KeyboardInterrupt:
+                self.hold()
+                raise KeyboardInterrupt
 
     def _ramp_to_setpoint_and_wait(self, ax, cmd, setpoint):
         error = 0.2e-3

--- a/qcodes/instrument_drivers/signal_hound/USB_SA124B.py
+++ b/qcodes/instrument_drivers/signal_hound/USB_SA124B.py
@@ -4,7 +4,6 @@ import ctypes as ct
 import logging
 
 from qcodes import Instrument, validators as vals
-from qcodes.instrument.parameter import ManualParameter
 
 
 class SignalHound_USB_SA124B(Instrument):
@@ -68,28 +67,28 @@ class SignalHound_USB_SA124B(Instrument):
                            label='Frequency ',
                            unit='Hz',
                            initial_value=5e9,
-                           parameter_class=ManualParameter,
+                           get_cmd=None, set_cmd=None,
                            vals=vals.Numbers())
         self.add_parameter('span',
                            label='Span ',
                            unit='Hz',
                            initial_value=.25e6,
-                           parameter_class=ManualParameter,
+                           get_cmd=None, set_cmd=None,
                            vals=vals.Numbers())
         self.add_parameter('power',
                            label='Power ',
                            unit='dBm',
                            initial_value=0,
-                           parameter_class=ManualParameter,
+                           get_cmd=None, set_cmd=None,
                            vals=vals.Numbers(max_value=20))
         self.add_parameter('ref_lvl',
                            label='Reference power ',
                            unit='dBm',
                            initial_value=0,
-                           parameter_class=ManualParameter,
+                           get_cmd=None, set_cmd=None,
                            vals=vals.Numbers(max_value=20))
         self.add_parameter('external_reference',
-                           parameter_class=ManualParameter,
+                           get_cmd=None, set_cmd=None,
                            initial_value=False,
                            vals=vals.Bool())
         self.add_parameter('device_type',
@@ -97,37 +96,37 @@ class SignalHound_USB_SA124B(Instrument):
 
         self.add_parameter('device_mode',
                            initial_value='sweeping',
-                           parameter_class=ManualParameter,
+                           get_cmd=None, set_cmd=None,
                            vals=vals.Anything())
         self.add_parameter('acquisition_mode',
-                           parameter_class=ManualParameter,
+                           get_cmd=None, set_cmd=None,
                            initial_value='average',
                            vals=vals.Enum('average', 'min-max'))
         self.add_parameter('scale',
-                           parameter_class=ManualParameter,
+                           get_cmd=None, set_cmd=None,
                            initial_value='log-scale',
                            vals=vals.Enum('log-scale', 'lin-scale',
                                           'log-full-scale', 'lin-full-scale'))
         self.add_parameter('running',
-                           parameter_class=ManualParameter,
+                           get_cmd=None, set_cmd=None,
                            initial_value=False,
                            vals=vals.Bool())
         self.add_parameter('decimation',
-                           parameter_class=ManualParameter,
+                           get_cmd=None, set_cmd=None,
                            initial_value=1,
                            vals=vals.Ints(1, 8))
         self.add_parameter('bandwidth',
                            label='Bandwidth',
                            unit='Hz',
                            initial_value=0,
-                           parameter_class=ManualParameter,
+                           get_cmd=None, set_cmd=None,
                            vals=vals.Numbers())
         # rbw Resolution bandwidth in Hz. RBW can be arbitrary.
         self.add_parameter('rbw',
                            label='Resolution Bandwidth',
                            unit='Hz',
                            initial_value=1e3,
-                           parameter_class=ManualParameter,
+                           get_cmd=None, set_cmd=None,
                            vals=vals.Numbers())
         # vbw Video bandwidth in Hz. VBW must be less than or equal to RBW.
         #  VBW can be arbitrary. For best performance use RBW as the VBW.
@@ -135,7 +134,7 @@ class SignalHound_USB_SA124B(Instrument):
                            label='Video Bandwidth',
                            unit='Hz',
                            initial_value=1e3,
-                           parameter_class=ManualParameter,
+                           get_cmd=None, set_cmd=None,
                            vals=vals.Numbers())
 
         self.openDevice()

--- a/qcodes/instrument_drivers/stanford_research/SIM928.py
+++ b/qcodes/instrument_drivers/stanford_research/SIM928.py
@@ -3,7 +3,6 @@ import logging
 import numpy as np
 import time
 
-from qcodes.instrument.parameter import ManualParameter
 from qcodes.instrument.visa import VisaInstrument
 from qcodes.utils import validators as vals
 
@@ -60,12 +59,12 @@ class SIM928(VisaInstrument):
                                label="Step size when changing the voltage "
                                      "smoothly on module "
                                      "{}".format(module_name),
-                               parameter_class=ManualParameter,
+                               get_cmd=None, set_cmd=None,
                                vals=vals.Numbers(0, 20), initial_value=0.005)
         self.add_parameter('smooth_timestep', unit='s',
                            label="Delay between sending the write commands"
                                  "when changing the voltage smoothly",
-                           parameter_class=ManualParameter,
+                           get_cmd=None, set_cmd=None,
                            vals=vals.Numbers(0, 1), initial_value=0.05)
 
         super().connect_message()

--- a/qcodes/instrument_drivers/stanford_research/SR560.py
+++ b/qcodes/instrument_drivers/stanford_research/SR560.py
@@ -1,5 +1,4 @@
 from qcodes import Instrument
-from qcodes.instrument.parameter import ManualParameter
 from qcodes.instrument.parameter import MultiParameter
 from qcodes.utils.validators import Bool, Enum
 
@@ -83,27 +82,27 @@ class SR560(Instrument):
                  10000, 20000, 50000]
 
         self.add_parameter('cutoff_lo',
-                           parameter_class=ManualParameter,
+                           get_cmd=None, set_cmd=None,
                            initial_value='DC',
                            label='High pass',
                            unit='Hz',
                            vals=Enum(*cutoffs))
 
         self.add_parameter('cutoff_hi',
-                           parameter_class=ManualParameter,
+                           get_cmd=None, set_cmd=None,
                            initial_value=1e6,
                            label='Low pass',
                            unit='Hz',
                            vals=Enum(*cutoffs))
 
         self.add_parameter('invert',
-                           parameter_class=ManualParameter,
+                           get_cmd=None, set_cmd=None,
                            initial_value=True,
                            label='Inverted output',
                            vals=Bool())
 
         self.add_parameter('gain',
-                           parameter_class=ManualParameter,
+                           get_cmd=None, set_cmd=None,
                            initial_value=10,
                            label='Gain',
                            unit=None,

--- a/qcodes/tests/instrument_mocks.py
+++ b/qcodes/tests/instrument_mocks.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from qcodes.instrument.base import Instrument
 from qcodes.utils.validators import Numbers
-from qcodes.instrument.parameter import MultiParameter, ManualParameter, ArrayParameter
+from qcodes.instrument.parameter import MultiParameter, Parameter, ArrayParameter
 from qcodes.instrument.channel import InstrumentChannel, ChannelList
 
 class MockParabola(Instrument):
@@ -25,13 +25,15 @@ class MockParabola(Instrument):
         # Instrument parameters
         for parname in ['x', 'y', 'z']:
             self.add_parameter(parname, unit='a.u.',
-                               parameter_class=ManualParameter,
-                               vals=Numbers(), initial_value=0)
+                               parameter_class=Parameter,
+                               vals=Numbers(), initial_value=0,
+                               get_cmd=None, set_cmd=None)
 
         self.add_parameter('noise', unit='a.u.',
                            label='white noise amplitude',
-                           parameter_class=ManualParameter,
-                           vals=Numbers(), initial_value=0)
+                           parameter_class=Parameter,
+                           vals=Numbers(), initial_value=0,
+                           get_cmd=None, set_cmd=None)
 
         self.add_parameter('parabola', unit='a.u.',
                            get_cmd=self._measure_parabola)
@@ -65,10 +67,12 @@ class MockMetaParabola(Instrument):
         # Instrument parameters
         for parname in ['x', 'y', 'z']:
             self.add_parameter(parname, unit='a.u.',
-                               parameter_class=ManualParameter,
-                               vals=Numbers(), initial_value=0)
-        self.add_parameter('gain', parameter_class=ManualParameter,
-                           initial_value=1)
+                               parameter_class=Parameter,
+                               vals=Numbers(), initial_value=0,
+                               get_cmd=None, set_cmd=None)
+        self.add_parameter('gain', parameter_class=Parameter,
+                           initial_value=1,
+                           get_cmd=None, set_cmd=None)
 
         self.add_parameter('parabola', unit='a.u.',
                            get_cmd=self._get_parabola)
@@ -101,11 +105,12 @@ class DummyInstrument(Instrument):
         # make gates
         for _, g in enumerate(gates):
             self.add_parameter(g,
-                               parameter_class=ManualParameter,
+                               parameter_class=Parameter,
                                initial_value=0,
                                label='Gate {}'.format(g),
                                unit="V",
-                               vals=Numbers(-800, 400))
+                               vals=Numbers(-800, 400),
+                               get_cmd=None, set_cmd=None)
 
 class DummyChannel(InstrumentChannel):
     """
@@ -119,11 +124,12 @@ class DummyChannel(InstrumentChannel):
 
         # Add the various channel parameters
         self.add_parameter('temperature',
-                           parameter_class=ManualParameter,
+                           parameter_class=Parameter,
                            initial_value=0,
                            label="Temperature_{}".format(channel),
                            unit='K',
-                           vals=Numbers(0, 300))
+                           vals=Numbers(0, 300),
+                           get_cmd=None, set_cmd=None)
 
         self.add_parameter(name='dummy_multi_parameter',
                            parameter_class=MultiSetPointParam)

--- a/qcodes/tests/test_channels.py
+++ b/qcodes/tests/test_channels.py
@@ -3,7 +3,7 @@ import unittest
 
 from qcodes.tests.instrument_mocks import DummyChannelInstrument, DummyChannel
 from qcodes.utils.validators import Numbers
-from qcodes.instrument.parameter import ManualParameter
+from qcodes.instrument.parameter import Parameter
 
 from hypothesis import given, settings
 import hypothesis.strategies as hst
@@ -142,7 +142,7 @@ class TestChannelsLoop(TestCase):
                            data.testchanneldummy_ChanA_temperature.ndarray)
 
     def test_loop_measure_all_channels(self):
-        p1 = ManualParameter(name='p1', vals=Numbers(-10, 10))
+        p1 = Parameter(name='p1', vals=Numbers(-10, 10), get_cmd=None, set_cmd=None)
         loop = Loop(p1.sweep(-10, 10, 1), 1e-6).each(self.instrument.channels.temperature)
         data = loop.run()
         self.assertEqual(data.p1_set.ndarray.shape, (21, ))
@@ -151,7 +151,7 @@ class TestChannelsLoop(TestCase):
             self.assertEqual(getattr(data, 'testchanneldummy_Chan{}_temperature'.format(chan)).ndarray.shape, (21,))
 
     def test_loop_measure_channels_individually(self):
-        p1 = ManualParameter(name='p1', vals=Numbers(-10, 10))
+        p1 = Parameter(name='p1', vals=Numbers(-10, 10), get_cmd=None, set_cmd=None)
         loop = Loop(p1.sweep(-10, 10, 1), 1e-6).each(self.instrument.channels[0].temperature,
                                                      self.instrument.channels[1].temperature,
                                                      self.instrument.channels[2].temperature,
@@ -164,7 +164,7 @@ class TestChannelsLoop(TestCase):
     @given(values=hst.lists(hst.floats(0, 300), min_size=4, max_size=4))
     @settings(max_examples=10)
     def test_loop_measure_channels_by_name(self, values):
-        p1 = ManualParameter(name='p1', vals=Numbers(-10, 10))
+        p1 = Parameter(name='p1', vals=Numbers(-10, 10), get_cmd=None, set_cmd=None)
         for i in range(4):
             self.instrument.channels[i].temperature(values[i])
         loop = Loop(p1.sweep(-10, 10, 1), 1e-6).each(self.instrument.A.temperature,

--- a/qcodes/tests/test_combined_loop.py
+++ b/qcodes/tests/test_combined_loop.py
@@ -7,7 +7,7 @@ import hypothesis.strategies as hst
 from .instrument_mocks import DummyInstrument
 from qcodes.instrument.parameter import combine
 from qcodes import Task, Loop
-from qcodes.instrument.parameter import ManualParameter
+from qcodes.instrument.parameter import Parameter
 
 
 class TestLoopCombined(TestCase):
@@ -38,7 +38,7 @@ class TestLoopCombined(TestCase):
                                y_set.reshape(npoints, 1),
                                z_set.reshape(npoints, 1)))
 
-        parameters = [ManualParameter(name) for name in ["X", "Y", "Z"]]
+        parameters = [Parameter(name, get_cmd=None, set_cmd=None) for name in ["X", "Y", "Z"]]
 
         sweep_values = combine(*parameters,
                                name="combined").sweep(setpoints)
@@ -72,7 +72,7 @@ class TestLoopCombined(TestCase):
         setpoints = np.hstack((x_set.reshape(npoints, 1),
                                y_set.reshape(npoints, 1),
                                z_set.reshape(npoints, 1)))
-        parameters = [ManualParameter(name) for name in ["X", "Y", "Z"]]
+        parameters = [Parameter(name, get_cmd=None, set_cmd=None) for name in ["X", "Y", "Z"]]
         sweep_values = combine(*parameters,
                                name="combined").sweep(setpoints)
 
@@ -110,7 +110,7 @@ class TestLoopCombined(TestCase):
         setpoints = np.hstack((x_set.reshape(npoints, 1),
                                y_set.reshape(npoints, 1),
                                z_set.reshape(npoints, 1)))
-        parameters = [ManualParameter(name) for name in ["X", "Y", "Z"]]
+        parameters = [Parameter(name, get_cmd=None, set_cmd=None) for name in ["X", "Y", "Z"]]
         sweep_values = combine(*parameters,
                                name="combined").sweep(setpoints)
 
@@ -151,7 +151,7 @@ class TestLoopCombined(TestCase):
         setpoints = np.hstack((y_set.reshape(npoints, 1),
                                z_set.reshape(npoints, 1)))
 
-        parameters = [ManualParameter(name) for name in ["X", "Y", "Z"]]
+        parameters = [Parameter(name, get_cmd=None, set_cmd=None) for name in ["X", "Y", "Z"]]
         sweep_values = combine(parameters[1], parameters[2],
                                name="combined").sweep(setpoints)
 

--- a/qcodes/tests/test_helpers.py
+++ b/qcodes/tests/test_helpers.py
@@ -239,7 +239,12 @@ class TestWaitSecs(TestCase):
             finish_clock = time.perf_counter() + secs
             secs_out = wait_secs(finish_clock)
             self.assertGreater(secs_out, secs - 1e-4)
-            self.assertLessEqual(secs_out, secs)
+            # add a tiny offset as this test may fail if
+            # otherwise if the two calls to perf_counter are close
+            # enough to return the same result as a + b - a cannot
+            # in general be assumed to be <= b in floating point
+            # math (here a is perf_counter() and b is the wait time
+            self.assertLessEqual(secs_out, secs+1e-14)
 
     def test_warning(self):
         with LogCapture() as logs:

--- a/qcodes/tests/test_instrument.py
+++ b/qcodes/tests/test_instrument.py
@@ -4,7 +4,7 @@ Test suite for  instument.*
 from unittest import TestCase
 from qcodes.instrument.base import Instrument
 from .instrument_mocks import DummyInstrument, MockParabola
-from qcodes.instrument.parameter import ManualParameter
+from qcodes.instrument.parameter import Parameter
 import gc
 
 
@@ -75,7 +75,7 @@ class TestInstrument(TestCase):
         # by desgin one gets the parameter if a function exists and has same
         # name
         dac1 = self.instrument['dac1']
-        self.assertTrue(isinstance(dac1, ManualParameter))
+        self.assertTrue(isinstance(dac1, Parameter))
 
     def test_instances(self):
         instruments = [self.instrument, self.instrument2]
@@ -99,13 +99,15 @@ class TestInstrument(TestCase):
 
     def test_snapshot_value(self):
         self.instrument.add_parameter('has_snapshot_value',
-                                      parameter_class=ManualParameter,
+                                      parameter_class=Parameter,
                                       initial_value=42,
-                                      snapshot_value=True)
+                                      snapshot_value=True,
+                                      get_cmd=None, set_cmd=None)
         self.instrument.add_parameter('no_snapshot_value',
-                                      parameter_class=ManualParameter,
+                                      parameter_class=Parameter,
                                       initial_value=42,
-                                      snapshot_value=False)
+                                      snapshot_value=False,
+                                      get_cmd=None, set_cmd=None)
 
         snapshot = self.instrument.snapshot()
 

--- a/qcodes/tests/test_loop.py
+++ b/qcodes/tests/test_loop.py
@@ -8,7 +8,7 @@ from qcodes.loops import Loop
 from qcodes.actions import Task, Wait, BreakIf, _QcodesBreak
 from qcodes.station import Station
 from qcodes.data.data_array import DataArray
-from qcodes.instrument.parameter import ManualParameter
+from qcodes.instrument.parameter import Parameter
 from qcodes.utils.validators import Numbers
 from qcodes.utils.helpers import LogCapture
 
@@ -18,9 +18,9 @@ from .instrument_mocks import MultiGetter
 class TestLoop(TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.p1 = ManualParameter('p1', vals=Numbers(-10, 10))
-        cls.p2 = ManualParameter('p2', vals=Numbers(-10, 10))
-        cls.p3 = ManualParameter('p3', vals=Numbers(-10, 10))
+        cls.p1 = Parameter('p1', get_cmd=None, set_cmd=None, vals=Numbers(-10, 10))
+        cls.p2 = Parameter('p2', get_cmd=None, set_cmd=None,  vals=Numbers(-10, 10))
+        cls.p3 = Parameter('p3', get_cmd=None, set_cmd=None,  vals=Numbers(-10, 10))
         Station().set_measurement(cls.p2, cls.p3)
 
     def test_nesting(self):
@@ -448,7 +448,7 @@ class TestLoop(TestCase):
         self.assertEqual(len(f_calls), 1)
 
 
-class AbortingGetter(ManualParameter):
+class AbortingGetter(Parameter):
     """
     A manual parameter that can only be measured n times
     before it aborts the loop that's measuring it.
@@ -474,7 +474,7 @@ class Test_halt(TestCase):
         self.res = list(np.arange(0, abort_after-1, 1.))
         [self.res.append(float('nan')) for i in range(0, abort_after-1)]
 
-        p1 = AbortingGetter('p1', count=abort_after, vals=Numbers(-10, 10))
+        p1 = AbortingGetter('p1', count=abort_after, vals=Numbers(-10, 10), set_cmd=None)
         loop = Loop(p1.sweep(0, abort_after, 1), 0.005).each(p1)
         # we want to test what's in data, so get it ahead of time
         # because loop.run will not return.
@@ -486,7 +486,7 @@ class Test_halt(TestCase):
 
 class TestMetaData(TestCase):
     def test_basic(self):
-        p1 = AbortingGetter('p1', count=2, vals=Numbers(-10, 10))
+        p1 = AbortingGetter('p1', count=2, vals=Numbers(-10, 10), set_cmd=None)
         sv = p1[1:3:1]
         loop = Loop(sv)
 

--- a/qcodes/tests/test_measure.py
+++ b/qcodes/tests/test_measure.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 from datetime import datetime
 
-from qcodes.instrument.parameter import ManualParameter
+from qcodes.instrument.parameter import Parameter
 from qcodes.measure import Measure
 
 from .instrument_mocks import MultiGetter, MultiSetPointParam
@@ -11,7 +11,7 @@ from numpy.testing import assert_array_equal
 
 class TestMeasure(TestCase):
     def setUp(self):
-        self.p1 = ManualParameter('P1', initial_value=1)
+        self.p1 = Parameter('P1', initial_value=1, get_cmd=None, set_cmd=None)
 
     def test_simple_scalar(self):
         data = Measure(self.p1).run_temp()

--- a/qcodes/tests/test_parameter.py
+++ b/qcodes/tests/test_parameter.py
@@ -8,7 +8,7 @@ from time import sleep
 from qcodes import Function
 from qcodes.instrument.parameter import (
     Parameter, ArrayParameter, MultiParameter,
-    ManualParameter, StandardParameter, InstrumentRefParameter)
+    InstrumentRefParameter)
 import qcodes.utils.validators as vals
 from qcodes.tests.instrument_mocks import DummyInstrument
 
@@ -65,7 +65,7 @@ class TestParameter(TestCase):
         self.assertEqual(p.name, name)
         self.assertEqual(p.label, name)
         self.assertEqual(p.unit, '')
-        self.assertEqual(p.full_name, name)
+        self.assertEqual(str(p), name)
 
         # default validator is all numbers
         p.validate(-1000)
@@ -103,7 +103,7 @@ class TestParameter(TestCase):
         self.assertEqual(p.name, name)
         self.assertEqual(p.label, label)
         self.assertEqual(p.unit, unit)
-        self.assertEqual(p.full_name, name)
+        self.assertEqual(str(p), name)
 
         with self.assertRaises(ValueError):
             p.validate(-1000)
@@ -256,7 +256,7 @@ class TestArrayParameter(TestCase):
         self.assertIsNone(p.setpoint_names)
         self.assertIsNone(p.setpoint_labels)
 
-        self.assertEqual(p.full_name, name)
+        self.assertEqual(str(p), name)
 
         self.assertEqual(p._get_count, 0)
         snap = p.snapshot(update=True)
@@ -333,12 +333,12 @@ class TestArrayParameter(TestCase):
         for instrument in blank_instruments:
             p = SimpleArrayParam([6, 7], 'fred', (2,))
             p._instrument = instrument
-            self.assertEqual(p.full_name, 'fred')
+            self.assertEqual(str(p), 'fred')
 
         # and finally an instrument that really has a name
         p = SimpleArrayParam([6, 7], 'wilma', (2,))
         p._instrument = named_instrument
-        self.assertEqual(p.full_name, 'astro_wilma')
+        self.assertEqual(str(p), 'astro_wilma')
 
     def test_constructor_errors(self):
         bad_constructors = [
@@ -392,7 +392,7 @@ class TestMultiParameter(TestCase):
         self.assertIsNone(p.setpoint_names)
         self.assertIsNone(p.setpoint_labels)
 
-        self.assertEqual(p.full_name, name)
+        self.assertEqual(str(p), name)
 
         self.assertEqual(p._get_count, 0)
         snap = p.snapshot(update=True)
@@ -488,7 +488,7 @@ class TestMultiParameter(TestCase):
             p = SimpleMultiParam([0, [1, 2, 3], [[4, 5], [6, 7]]],
                                  name, names, shapes)
             p._instrument = instrument
-            self.assertEqual(p.full_name, name)
+            self.assertEqual(str(p), name)
 
             self.assertEqual(p.full_names, names)
 
@@ -496,7 +496,7 @@ class TestMultiParameter(TestCase):
         p = SimpleMultiParam([0, [1, 2, 3], [[4, 5], [6, 7]]],
                              name, names, shapes)
         p._instrument = named_instrument
-        self.assertEqual(p.full_name, 'astro_mixed_dimensions')
+        self.assertEqual(str(p), 'astro_mixed_dimensions')
 
         self.assertEqual(p.full_names, ['astro_0D', 'astro_1D', 'astro_2D'])
 
@@ -521,7 +521,7 @@ class TestManualParameter(TestCase):
 
     def test_bare_function(self):
         # not a use case we want to promote, but it's there...
-        p = ManualParameter('test')
+        p = Parameter('test', get_cmd=None, set_cmd=None)
 
         def doubler(x):
             p.set(x * 2)
@@ -551,7 +551,7 @@ class TestStandardParam(TestCase):
         return '{:d}'.format(val)
 
     def test_param_cmd_with_parsing(self):
-        p = StandardParameter('p_int', get_cmd=self.get_p, get_parser=int,
+        p = Parameter('p_int', get_cmd=self.get_p, get_parser=int,
                               set_cmd=self.set_p, set_parser=self.parse_set_p)
 
         p(5)

--- a/qcodes/tests/test_sweep_values.py
+++ b/qcodes/tests/test_sweep_values.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from qcodes.instrument.parameter import StandardParameter, ManualParameter
+from qcodes.instrument.parameter import Parameter
 from qcodes.instrument.sweep_values import SweepValues
 
 from qcodes.utils.validators import Numbers
@@ -7,10 +7,10 @@ from qcodes.utils.validators import Numbers
 
 class TestSweepValues(TestCase):
     def setUp(self):
-        self.c0 = ManualParameter('c0', vals=Numbers(-10, 10))
-        self.c1 = ManualParameter('c1')
+        self.c0 = Parameter('c0', vals=Numbers(-10, 10), get_cmd=None, set_cmd=None)
+        self.c1 = Parameter('c1', get_cmd=None, set_cmd=None)
 
-        self.getter = StandardParameter('c2', get_cmd=lambda: 42)
+        self.getter = Parameter('c2', get_cmd=lambda: 42)
 
     def test_errors(self):
         c0 = self.c0
@@ -103,7 +103,7 @@ class TestSweepValues(TestCase):
         self.assertFalse(c0_sv6 is c0_sv7)
 
     def test_base(self):
-        p = ManualParameter('p')
+        p = Parameter('p', get_cmd=None, set_cmd=None)
         with self.assertRaises(NotImplementedError):
             iter(SweepValues(p))
 


### PR DESCRIPTION
Fixes #issuenumber.

Changes proposed in this pull request:
- New driver for Holzworth Microwave source


`import qcodes
import socket
import logging
from qcodes import IPInstrument, Instrument, validators as vals


class HS9004A(IPInstrument):

#    qcodes IPInstrument class allows direct communication to a TCP/IP device using the "Socket" package.
#    Arguments:
#    def __init__(name, address, port, timeout, terminator, persistent, 
#                    write_confirmation, **kwargs), 
#    Name = Name given to instrument in script
#    Address = IP address of instrument
#    Port = IP port within IP address (9760 for Holzworth on BlueFors)
#    Timeout = Seconds to allow for responses
#    Terminator = Character to end each send command. ('\n' for C based devices)
#    Persistent (True/False) = Whether to leave socket open between send commands.
#    write_confirmation (True/False) – Whether there are some responses we need to read.
    
    



    def __init__(self, name, address='192.168.150.11', port=9760, timeout=5, terminator='\n', persistent=True, write_confirmation=True, **kwargs):
        
        super().__init__(name, address=address, port=port,
                         terminator=terminator, timeout=timeout, **kwargs)
        
        self._address = '192.168.150.11'
        self._port = 9760
        self._timeout = 2
        self._terminator = '\n'
        self._confirmation = write_confirmation
        self._buffer_size = 128 # TCP Buffer size. Reset to 1400 in case of error (works 
                                    # with this value)
        
        print('Syntax: "Name.ch{}_Parameter(\'Parameter_Value\')" \n Parameters: "Frequency, Power, Phase, Output (1 or 0 Boolean), Temperature (get only)"' )        
        

#    Write .format() commands to send to the instrument.
#    Write seperate set command for each setting for ease of incorporating the units.
#    getcmd works for all settings.

        
        def setfreq(channel, setting): #Works.
            return ':CH{}:'.format(channel) + setting + ':' + '{}' + 'MHz'
            
        def setpwr(channel, setting): #Works.
            return ':CH{}:'.format(channel) + setting + ':' + '{}' + 'dBm'

        def setphase(channel, setting): #Works.
            return ':CH{}:'.format(channel) + setting + ':' + '{}' + 'deg'
        
        def RFoutput(channel, setting): # Check mapping
            return ':CH{}:'.format(channel) + setting + ':' + '{}'
       
        def getcmd(channel, setting): # WORKS FOR ALL, DO NOT CHANGE!!
            return ':CH{}:'.format(channel) + setting + '?'
        
        
        for chan in [1,2,3,4]:
            
            self.add_parameter('ch{}_freq'.format(chan),
                               label = 'Channel {} Frequency'.format(chan),
                               get_cmd = getcmd(chan, 'FREQ'),
                               set_cmd = setfreq(chan, 'FREQ'),
                               get_parser = str,
                               set_parser = float,
                              )
            
            self.add_parameter('ch{}_pwr'.format(chan),
                               label = 'Channel {} Power'.format(chan),
                               get_cmd = getcmd(chan, 'PWR'),
                               set_cmd = setpwr(chan, 'PWR'),
                               get_parser = str,
                               set_parser = float,
                              )
            
            self.add_parameter('ch{}_phase'.format(chan),
                               label = 'Channel {} Phase'.format(chan),
                               get_cmd = getcmd(chan, 'PHASE'),
                               set_cmd = setphase(chan, 'PHASE'),
                               get_parser = str,
                               set_parser = float,
                              )
           
            self.add_parameter('ch{}_output'.format(chan),
                               label = 'Channel {} Output'.format(chan),
                               get_cmd = getcmd(chan, 'PWR:RF'),
                               set_cmd = RFoutput(chan, 'PWR:RF'),
                               get_parser = str,
                               #set_parser = float,
                               val_mapping={1:'ON', 0:'OFF'},
                              )            
            
            self.add_parameter('ch{}_temp'.format(chan),
                               label = 'Channel {} Temperature'.format(chan),
                               get_cmd = getcmd(chan, 'TEMP'),
                               get_parser = str,
                              )            
            
            `

- 


@mention one core developer
@ https://github.com/Dominik-Vogel @Dominic-Vogel